### PR TITLE
Android SDK Build Tools version removed from build.gradle file

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,7 +19,6 @@ def safeExtGet(prop, fallback) {
 
 android {
     compileSdkVersion safeExtGet('WalletManager_compileSdkVersion', 30)
-    buildToolsVersion safeExtGet('WalletManager_buildToolsVersion', '30.0.0')
     defaultConfig {
         minSdkVersion safeExtGet('WalletManager_minSdkVersion', 16)
         targetSdkVersion safeExtGet('WalletManager_targetSdkVersion', 30)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('WalletManager_compileSdkVersion', 29)
-    buildToolsVersion safeExtGet('WalletManager_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('WalletManager_compileSdkVersion', 30)
+    buildToolsVersion safeExtGet('WalletManager_buildToolsVersion', '30.0.0')
     defaultConfig {
         minSdkVersion safeExtGet('WalletManager_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('WalletManager_targetSdkVersion', 29)
+        targetSdkVersion safeExtGet('WalletManager_targetSdkVersion', 30)
         versionCode 1
         versionName "1.0"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-wallet-manager",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Provides some Apple Wallet's functionality, like adding passes, removing passes and checking passises for existing.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
WARNING:The specified Android SDK Build Tools version (29.0.2) is ignored, as it is below the minimum supported version (30.0.3) for Android Gradle Plugin 7.4.2.

Android SDK Build Tools 30.0.3 will be used.

To suppress this warning, remove "buildToolsVersion '29.0.2'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.

WARNING:The specified Android SDK Build Tools version (29.0.2) is ignored, as it is below the minimum supported version (30.0.3) for Android Gradle Plugin 7.4.2.

Android SDK Build Tools 30.0.3 will be used.

To suppress this warning, remove "buildToolsVersion '29.0.2'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.