### PR TITLE
Adds check if wallet can be accessed

### DIFF
--- a/ios/WalletManager.m
+++ b/ios/WalletManager.m
@@ -16,14 +16,17 @@ static NSString *const rejectCode = @"wallet";
 
 RCT_EXPORT_MODULE(WalletManager);
 
-RCT_REMAP_METHOD(canAddPasses, resolver: (RCTPromiseResolveBlock)resolve
-     rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(
+                  canAddPasses:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  BOOL allowsPass = [PKAddPassesViewController canAddPasses];
-  if (allowsPass) {
+  BOOL showPass = [PKAddPassesViewController canAddPasses];
+  if (showPass) {
     resolve(@(YES));
+    return;
   }
   resolve(@(NO));
+  return;
 }
 
 RCT_EXPORT_METHOD(

--- a/ios/WalletManager.m
+++ b/ios/WalletManager.m
@@ -16,8 +16,14 @@ static NSString *const rejectCode = @"wallet";
 
 RCT_EXPORT_MODULE(WalletManager);
 
-RCT_EXPORT_METHOD(canAddPasses:(RCTResponseSenderBlock)callback) {
-  callback(@[@([PKAddPassesViewController canAddPasses])]);
+RCT_REMAP_METHOD(canAddPasses, resolver: (RCTPromiseResolveBlock)resolve
+     rejecter:(RCTPromiseRejectBlock)reject)
+{
+  BOOL *allowsPass = [PKAddPassesViewController canAddPasses];
+  if (allowsPass) {
+    resolve(@(YES));
+  }
+  resolve(@(NO));
 }
 
 RCT_EXPORT_METHOD(

--- a/ios/WalletManager.m
+++ b/ios/WalletManager.m
@@ -19,7 +19,7 @@ RCT_EXPORT_MODULE(WalletManager);
 RCT_REMAP_METHOD(canAddPasses, resolver: (RCTPromiseResolveBlock)resolve
      rejecter:(RCTPromiseRejectBlock)reject)
 {
-  BOOL *allowsPass = [PKAddPassesViewController canAddPasses];
+  BOOL allowsPass = [PKAddPassesViewController canAddPasses];
   if (allowsPass) {
     resolve(@(YES));
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { NativeModules, Platform, Linking } from 'react-native';
 
 type WalletManagerType = {
+  canAddPasses(): Promise<boolean>;
   addPassFromUrl(url: string): Promise<boolean>;
   hasPass(cardIdentifier: string, serialNumber?: string): Promise<boolean>;
   removePass(cardIdentifier: string, serialNumber?: string): Promise<boolean>;
@@ -10,6 +11,12 @@ type WalletManagerType = {
 const { WalletManager } = NativeModules;
 
 export default {
+  canAddPasses: async () => {
+    if (Platform.OS === 'android') {
+      throw new Error('canAddPasses method not available on Android');
+    }
+    return await WalletManager.canAddPasses();
+  },
   addPassFromUrl:
     Platform.OS === 'ios'
       ? WalletManager.addPassFromUrl


### PR DESCRIPTION
Adds ability to check for iOS `PKAddPassesViewController canAddPasses` method with
const canAddPasses = await WalletManager.canAddPasses();

I created this check as I was getting a crash on devices that do not have the Wallet app installed.

I am not familiar with Objective C, so this code can likely be improved. 
After trial and error, this seems to run correctly without errors.