### PR TITLE
chore: added support RN v 0.72.x and android SDK v 33

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,11 +18,11 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('WalletManager_compileSdkVersion', 30)
-    buildToolsVersion safeExtGet('WalletManager_buildToolsVersion', '29.0.2')
+    compileSdkVersion safeExtGet('WalletManager_compileSdkVersion', 33)
+    buildToolsVersion safeExtGet('WalletManager_buildToolsVersion', '33.0.0')
     defaultConfig {
         minSdkVersion safeExtGet('WalletManager_minSdkVersion', 16)
-        targetSdkVersion safeExtGet('WalletManager_targetSdkVersion', 29)
+        targetSdkVersion safeExtGet('WalletManager_targetSdkVersion', 33)
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
PR adds compatibility with latest RN v 0.72.x, because it was not possible to build application.
Resolved build error: In order to compile Java 9+ source, please set compileSdkVersion to 30 or above

Added support to android target SDK v 33 which is minimum required by Google Play right now.

PR resolves #14 