### PR TITLE
feat: add showAddPassControllerFromFile method to the iOS module

### DIFF
--- a/ios/WalletManager.m
+++ b/ios/WalletManager.m
@@ -30,6 +30,21 @@ RCT_EXPORT_METHOD(
 }
 
 RCT_EXPORT_METHOD(
+                  showAddPassControllerFromFile:(NSString *)filepath
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  ) {
+    NSData* data =[[NSData alloc]init];
+
+    data = [NSData dataWithContentsOfFile:filepath];
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [self showViewControllerWithData:data resolver:resolve rejecter:reject];
+    });
+
+}
+
+RCT_EXPORT_METHOD(
                   addPassFromUrl:(NSString *)pass
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { NativeModules, Platform, Linking } from 'react-native';
 
 type WalletManagerType = {
   canAddPasses(): Promise<boolean>;
+  showAddPassControllerFromFile(url: string): Promise<boolean>;
   addPassFromUrl(url: string): Promise<boolean>;
   hasPass(cardIdentifier: string, serialNumber?: string): Promise<boolean>;
   removePass(cardIdentifier: string, serialNumber?: string): Promise<boolean>;
@@ -17,6 +18,9 @@ export default {
     }
     return await WalletManager.canAddPasses();
   },
+ showAddPassControllerFromFile: async(filePath) => {
+    return WalletManager.showAddPassControllerFromFile(filePath);
+  },
   addPassFromUrl:
     Platform.OS === 'ios'
       ? WalletManager.addPassFromUrl
@@ -30,6 +34,7 @@ export default {
       serialNumber != null ? serialNumber : null
     );
   },
+
   removePass: async (cardIdentifier: string, serialNumber?: string) => {
     if (Platform.OS === 'android') {
       throw new Error('removePass method not available on Android');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,6 @@ export default {
       serialNumber != null ? serialNumber : null
     );
   },
-
   removePass: async (cardIdentifier: string, serialNumber?: string) => {
     if (Platform.OS === 'android') {
       throw new Error('removePass method not available on Android');


### PR DESCRIPTION
Added **showAddPassControllerFromFile** method for iOS platform to pass in local filepath of .pkpass.

This PR resolves the issue [#20](https://github.com/dev-family/react-native-wallet-manager/issues/20)
