### PR TITLE
Fix IOS App crash issue when Wallet App is not installed

### DIFF
--- a/ios/WalletManager.m
+++ b/ios/WalletManager.m
@@ -40,7 +40,7 @@ RCT_EXPORT_METHOD(
         reject(@"file_error", @"Failed to load file", error);
         return;
     }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(dispatch_get_main_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [self showViewControllerWithData:data resolver:resolve rejecter:reject];
     });
 }

--- a/ios/WalletManager.m
+++ b/ios/WalletManager.m
@@ -51,7 +51,7 @@ RCT_EXPORT_METHOD(
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
                   ) {
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+  dispatch_async(dispatch_get_main_queue(), ^{
     NSURL *passURL = [[NSURL alloc] initWithString:pass];
     if (!passURL) {
       reject(rejectCode, @"The pass URL is invalid", nil);

--- a/ios/WalletManager.m
+++ b/ios/WalletManager.m
@@ -40,7 +40,7 @@ RCT_EXPORT_METHOD(
         reject(@"file_error", @"Failed to load file", error);
         return;
     }
-    dispatch_async(dispatch_get_main_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
         [self showViewControllerWithData:data resolver:resolve rejecter:reject];
     });
 }


### PR DESCRIPTION
The main reason for this issue is this error:

`Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Call must be made on main thread'`

**Fix:**
- Replaced  `dispatch_get_main_queue` with `dispatch_get_global_queue` in these methods `addPassFromUrl` and `showAddPassControllerFromFile`

Now when you call `showAddPassControllerFromFile` and the Wallet app is not installed you will receive this Alert manged by IOS

![image](https://github.com/user-attachments/assets/c2adb969-936b-4a8f-81e4-62fb7c07e427)



