### PR TITLE
chore: replace jcenter() with mavenCentral() in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
 
         dependencies {
@@ -50,7 +50,7 @@ repositories {
         url("$rootDir/../node_modules/react-native/android")
     }
     google()
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
This pull request updates the repository configuration in the `android/build.gradle` file to use `mavenCentral()` instead of `jcenter()`. This change helps ensure continued access to dependencies, as `jcenter()` is deprecated.

Dependency repository updates:

* Replaced `jcenter()` with `mavenCentral()` in both the `buildscript` and main `repositories` blocks of `android/build.gradle` to improve reliability and future compatibility. [[1]](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL5-R5) [[2]](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL53-R53)