### PR TITLE
feat: add support for custom headers in addPassFromUrl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ node_modules/
 npm-debug.log
 yarn-debug.log
 yarn-error.log
+.yarn/
 
 # BUCK
 buck-out/

--- a/android/src/main/java/com/reactnativewalletmanager/WalletManagerModule.kt
+++ b/android/src/main/java/com/reactnativewalletmanager/WalletManagerModule.kt
@@ -5,9 +5,13 @@ import android.content.Intent;
 import com.facebook.react.bridge.BaseActivityEventListener;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReadableMap;
 import com.google.android.gms.pay.PayClient;
 import com.google.android.gms.pay.Pay;
 import com.google.android.gms.pay.PayApiAvailabilityStatus;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 class WalletManagerModule(reactContext: ReactApplicationContext) : NativeWalletManagerSpec(reactContext) {
 
@@ -93,8 +97,71 @@ class WalletManagerModule(reactContext: ReactApplicationContext) : NativeWalletM
     promise.reject("UNSUPPORTED_PLATFORM", "This function is not supported on Android.")
   }
 
-  override fun addPassFromUrl(url: String, promise: Promise) {
-    promise.reject("UNSUPPORTED_PLATFORM", "This function is not supported on Android.")
+  override fun addPassFromUrl(url: String, headers: ReadableMap?, promise: Promise) {
+    val activity = currentActivity
+    if (activity == null) {
+      promise.reject("NO_ACTIVITY", "Current activity is unavailable")
+      return
+    }
+
+    // Validate URL before starting network request
+    val parsedUrl: URL
+    try {
+      parsedUrl = URL(url)
+    } catch (e: MalformedURLException) {
+      promise.reject("INVALID_URL", "The URL is invalid")
+      return
+    }
+
+    // Run network request on background thread
+    Thread {
+      var connection: HttpURLConnection? = null
+      try {
+        connection = parsedUrl.openConnection() as HttpURLConnection
+        connection.requestMethod = "GET"
+
+        // Add custom headers
+        headers?.let { map ->
+          val iterator = map.keySetIterator()
+          while (iterator.hasNextKey()) {
+            val key = iterator.nextKey()
+            connection.setRequestProperty(key, map.getString(key))
+          }
+        }
+
+        val responseCode = connection.responseCode
+        if (responseCode !in 200..299) {
+          promise.reject("HTTP_ERROR", "HTTP $responseCode")
+          return@Thread
+        }
+
+        val jwt = connection.inputStream.bufferedReader().use { it.readText() }
+
+        // Save to Google Wallet on main thread
+        activity.runOnUiThread {
+          addPassPromise = promise
+          try {
+            walletClient.savePassesJwt(jwt, activity, ADD_TO_GOOGLE_WALLET_REQUEST_CODE)
+          } catch (e: Exception) {
+            addPassPromise = null
+            when (e) {
+              is com.google.android.gms.common.api.ApiException -> {
+                val statusCode = e.statusCode
+                val statusMessage = com.google.android.gms.common.api.CommonStatusCodes.getStatusCodeString(statusCode)
+                promise.reject("API_ERROR", "Google Pay API error: $statusCode - $statusMessage")
+              }
+              else -> {
+                promise.reject("GENERAL_ERROR", e.message ?: "Failed to save pass")
+              }
+            }
+          }
+        }
+      } catch (e: Exception) {
+        promise.reject("NETWORK_ERROR", e.message ?: "Network request failed")
+      } finally {
+        connection?.disconnect()
+      }
+    }.start()
   }
 
   override fun hasPass(cardIdentifier: String, serialNumber: String?, promise: Promise) {

--- a/ios/WalletManager.mm
+++ b/ios/WalletManager.mm
@@ -23,9 +23,13 @@ WalletManagerImpl *walletManager = [[WalletManagerImpl alloc] init];
 }
 
 - (void)addPassFromUrl:(nonnull NSString *)url headers:(nullable NSDictionary *)headers resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
-  [walletManager addPassFromUrl:url headers:headers completion:^(BOOL added) {
-         resolve(@(added));
-     }];
+  [walletManager addPassFromUrl:url headers:headers completion:^(BOOL success, NSString *errorCode, NSString *errorMessage) {
+    if (success) {
+      resolve(@(YES));
+    } else {
+      reject(errorCode, errorMessage, nil);
+    }
+  }];
 }
 
 - (void)addPassToGoogleWallet:(nonnull NSString *)jwt resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {

--- a/ios/WalletManager.mm
+++ b/ios/WalletManager.mm
@@ -22,8 +22,8 @@ WalletManagerImpl *walletManager = [[WalletManagerImpl alloc] init];
     return std::make_shared<facebook::react::NativeWalletManagerSpecJSI>(params);
 }
 
-- (void)addPassFromUrl:(nonnull NSString *)url resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
-  [walletManager addPassFromUrl:url completion:^(BOOL added) {
+- (void)addPassFromUrl:(nonnull NSString *)url headers:(nullable NSDictionary *)headers resolve:(nonnull RCTPromiseResolveBlock)resolve reject:(nonnull RCTPromiseRejectBlock)reject {
+  [walletManager addPassFromUrl:url headers:headers completion:^(BOOL added) {
          resolve(@(added));
      }];
 }

--- a/ios/WalletManagerImpl.swift
+++ b/ios/WalletManagerImpl.swift
@@ -79,8 +79,8 @@ public class WalletManagerImpl: NSObject, @preconcurrency PKAddPassesViewControl
       }
 
       DispatchQueue.main.async {
-        self.showViewController(with: data)
         self.completion = completion
+        self.showViewController(with: data)
       }
     }.resume()
   }

--- a/ios/WalletManagerImpl.swift
+++ b/ios/WalletManagerImpl.swift
@@ -66,7 +66,7 @@ public class WalletManagerImpl: NSObject, @preconcurrency PKAddPassesViewControl
         return
       }
 
-      if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode != 200 {
+      if let httpResponse = response as? HTTPURLResponse, !(200...299).contains(httpResponse.statusCode) {
         DispatchQueue.main.async {
           completion(false, "HTTP_ERROR", "HTTP \(httpResponse.statusCode)")
         }
@@ -156,7 +156,11 @@ public class WalletManagerImpl: NSObject, @preconcurrency PKAddPassesViewControl
       return
     }
 
-    guard let root = UIApplication.shared.keyWindow?.rootViewController else {
+    guard let windowScene = UIApplication.shared.connectedScenes
+      .compactMap({ $0 as? UIWindowScene })
+      .first(where: { $0.activationState == .foregroundActive }),
+      let root = windowScene.windows.first(where: { $0.isKeyWindow })?.rootViewController
+    else {
       addPassCompletion(false, "NO_VIEW_CONTROLLER", "No root view controller found")
       return
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,25 @@
-import { Linking, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import WalletManager from './specs/NativeWalletManager';
 
 /**
  * Error codes that can be thrown by addPassFromUrl
  */
 export type WalletErrorCode =
+  // Shared error codes
   | 'INVALID_URL'
   | 'NETWORK_ERROR'
   | 'HTTP_ERROR'
+  | 'USER_CANCELLED'
+  // iOS-specific error codes
   | 'INVALID_DATA'
   | 'INVALID_PASS'
   | 'PASS_ALREADY_EXISTS'
   | 'NO_VIEW_CONTROLLER'
   | 'CONTROLLER_ERROR'
-  | 'USER_CANCELLED';
+  // Android-specific error codes
+  | 'NO_ACTIVITY'
+  | 'API_ERROR'
+  | 'GENERAL_ERROR';
 
 /**
  * Error object thrown when addPassFromUrl fails
@@ -40,11 +46,8 @@ export default {
     }
     return await WalletManager.addPassToGoogleWallet(jwt);
   },
-  addPassFromUrl:
-    Platform.OS === 'ios'
-      ? (url: string, headers?: Record<string, string>) =>
-          WalletManager.addPassFromUrl(url, headers ?? null)
-      : (url: string) => Linking.openURL(url),
+  addPassFromUrl: (url: string, headers?: Record<string, string>) =>
+    WalletManager.addPassFromUrl(url, headers ?? null),
   hasPass: async (cardIdentifier: string, serialNumber?: string) => {
     if (Platform.OS === 'android') {
       throw new Error('hasPass method not available on Android');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,6 @@ export type WalletErrorCode =
  */
 export type WalletError = Error & {
   code: WalletErrorCode;
-  message: string;
 };
 
 export default {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,8 @@ export default {
   },
   addPassFromUrl:
     Platform.OS === 'ios'
-      ? WalletManager.addPassFromUrl
+      ? (url: string, headers?: Record<string, string>) =>
+          WalletManager.addPassFromUrl(url, headers ?? null)
       : (url: string) => Linking.openURL(url),
   hasPass: async (cardIdentifier: string, serialNumber?: string) => {
     if (Platform.OS === 'android') {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,28 @@
 import { Linking, Platform } from 'react-native';
 import WalletManager from './specs/NativeWalletManager';
 
+/**
+ * Error codes that can be thrown by addPassFromUrl
+ */
+export type WalletErrorCode =
+  | 'INVALID_URL'
+  | 'NETWORK_ERROR'
+  | 'HTTP_ERROR'
+  | 'INVALID_DATA'
+  | 'INVALID_PASS'
+  | 'PASS_ALREADY_EXISTS'
+  | 'NO_VIEW_CONTROLLER'
+  | 'CONTROLLER_ERROR'
+  | 'USER_CANCELLED';
+
+/**
+ * Error object thrown when addPassFromUrl fails
+ */
+export type WalletError = Error & {
+  code: WalletErrorCode;
+  message: string;
+};
+
 export default {
   canAddPasses: async () => {
     return await WalletManager.canAddPasses();

--- a/src/specs/NativeWalletManager.ts
+++ b/src/specs/NativeWalletManager.ts
@@ -3,7 +3,7 @@ import { TurboModule, TurboModuleRegistry } from 'react-native';
 export interface Spec extends TurboModule {
   canAddPasses(): Promise<boolean>;
   showAddPassControllerFromFile(url: string): Promise<boolean>;
-  addPassFromUrl(url: string): Promise<boolean>;
+  addPassFromUrl(url: string, headers: Object | null): Promise<boolean>;
   hasPass(
     cardIdentifier: string,
     serialNumber: string | null


### PR DESCRIPTION
Hi thanks for the lib, I had trouble with authenticated URLs for the passes so I started to tweak the iOS code to support headers. Ended up reworking the API to get proper result codes and also implemented the addPassFromUrl on native Android to be ISO.

That's a lot of changes (breaking) and would need a new major. Feel free to merge or not, I'll maintain a fork meanwhile.

Thanks!